### PR TITLE
Upgraded to jetcd 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
   <artifactId>salus-telemetry-zone-watcher</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
+  <properties>
+    <jetcd.version>0.3.0</jetcd.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.kafka</groupId>
@@ -109,9 +113,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.mxsm</groupId>
+      <groupId>io.etcd</groupId>
       <artifactId>jetcd-launcher</artifactId>
-      <version>0.3.6</version>
+      <version>${jetcd.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/rackspace/salus/zw/handler/ExpiringZoneEventProcessor.java
+++ b/src/main/java/com/rackspace/salus/zw/handler/ExpiringZoneEventProcessor.java
@@ -19,14 +19,14 @@ package com.rackspace.salus.zw.handler;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.PTN_ZONE_EXPIRING;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.TRACKING_KEY_ZONE_EXPIRING;
 
-import com.coreos.jetcd.common.exception.ClosedClientException;
-import com.coreos.jetcd.common.exception.ClosedWatcherException;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.watch.WatchEvent;
-import com.coreos.jetcd.watch.WatchResponse;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
-import com.rackspace.salus.zw.services.ZoneStorageListener;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.zw.services.ZoneStorageListener;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.watch.WatchEvent;
+import io.etcd.jetcd.watch.WatchResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,64 +36,50 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ExpiringZoneEventProcessor extends ZoneEventProcessor {
+  final ByteSequence trackingKey = EtcdUtils.fromString(TRACKING_KEY_ZONE_EXPIRING);
 
   public ExpiringZoneEventProcessor(ZoneStorageListener listener, ZoneStorage zoneStorage) {
     super(listener, zoneStorage);
   }
 
   @Override
-  public void run() {
-    final ByteSequence trackingKey = ByteSequence.fromString(TRACKING_KEY_ZONE_EXPIRING);
+  public void accept(WatchResponse response) {
+    try {
+      for (WatchEvent event : response.getEvents()) {
 
-    while (zoneStorage.isRunning()) {
-      try {
-        final WatchResponse response = zoneWatcher.listen();
+        final String keyStr = event.getKeyValue().getKey().toString(StandardCharsets.UTF_8);
+        final Matcher matcher = PTN_ZONE_EXPIRING.matcher(keyStr);
 
-        try {
-          for (WatchEvent event : response.getEvents()) {
-
-            final String keyStr = event.getKeyValue().getKey().toStringUtf8();
-            final Matcher matcher = PTN_ZONE_EXPIRING.matcher(keyStr);
-
-            if (!matcher.matches()) {
-              log.warn("Unable to parse expiring event key={}", keyStr);
-              continue;
-            }
-
-            String resourceId = matcher.group("resourceId");
-            final ResolvedZone resolvedZone = ResolvedZone.fromKeyParts(
-                matcher.group("tenant"),
-                matcher.group("zoneName")
-            );
-
-            switch (event.getEventType()) {
-              case PUT:
-                // no action needed
-                break;
-              case DELETE:
-                // if the lease isn't expired, it means the poller came back up and
-                // the expiring entry was removed by the listener before the entry could time out.
-                if (zoneStorage.isLeaseExpired(event)) {
-                  listener.handleExpiredEnvoy(
-                      resolvedZone, resourceId, event.getPrevKV().getValue().toStringUtf8());
-                }
-                break;
-              case UNRECOGNIZED:
-                log.warn("Unknown expiring watcher event seen by zone watcher");
-                break;
-            }
-          }
-        } finally {
-          zoneStorage.incrementTrackingKeyVersion(trackingKey);
+        if (!matcher.matches()) {
+          log.warn("Unable to parse expiring event key={}", keyStr);
+          continue;
         }
-      } catch (InterruptedException e) {
-        log.warn("Interrupted while watching zone expected", e);
-      } catch (ClosedWatcherException | ClosedClientException e) {
-        log.debug("Stopping processing due to closure", e);
-        listener.handleExpectedZoneWatcherClosed(e);
-        return;
+
+        String resourceId = matcher.group("resourceId");
+        final ResolvedZone resolvedZone = ResolvedZone.fromKeyParts(
+            matcher.group("tenant"),
+            matcher.group("zoneName")
+        );
+
+        switch (event.getEventType()) {
+          case PUT:
+            // no action needed
+            break;
+          case DELETE:
+            // if the lease isn't expired, it means the poller came back up and
+            // the expiring entry was removed by the listener before the entry could time out.
+            if (zoneStorage.isLeaseExpired(event)) {
+              listener.handleExpiredEnvoy(
+                  resolvedZone, resourceId, event.getPrevKV().getValue().toString(StandardCharsets.UTF_8));
+            }
+            break;
+          case UNRECOGNIZED:
+            log.warn("Unknown expiring watcher event seen by zone watcher");
+            break;
+        }
       }
+    } finally {
+      zoneStorage.incrementTrackingKeyVersion(trackingKey);
     }
-    listener.handleExpectedZoneWatcherClosed(null);
   }
 }

--- a/src/main/java/com/rackspace/salus/zw/handler/ZoneEventProcessor.java
+++ b/src/main/java/com/rackspace/salus/zw/handler/ZoneEventProcessor.java
@@ -16,11 +16,13 @@
 
 package com.rackspace.salus.zw.handler;
 
-import com.coreos.jetcd.Watch.Watcher;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.zw.services.ZoneStorageListener;
+import io.etcd.jetcd.Watch.Watcher;
+import io.etcd.jetcd.watch.WatchResponse;
+import java.util.function.Consumer;
 
-public abstract class ZoneEventProcessor implements Runnable {
+public abstract class ZoneEventProcessor implements Consumer<WatchResponse> {
   Watcher zoneWatcher;
   ZoneStorageListener listener;
   ZoneStorage zoneStorage;

--- a/src/main/java/com/rackspace/salus/zw/services/EtcdWatchConnector.java
+++ b/src/main/java/com/rackspace/salus/zw/services/EtcdWatchConnector.java
@@ -23,15 +23,16 @@ import static com.rackspace.salus.telemetry.etcd.types.Keys.TRACKING_KEY_ZONE_AC
 import static com.rackspace.salus.telemetry.etcd.types.Keys.TRACKING_KEY_ZONE_EXPECTED;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.TRACKING_KEY_ZONE_EXPIRING;
 
-import com.coreos.jetcd.Watch.Watcher;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.options.WatchOption;
-import com.coreos.jetcd.options.WatchOption.Builder;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.zw.handler.ActiveZoneEventProcessor;
 import com.rackspace.salus.zw.handler.ExpectedZoneEventProcessor;
 import com.rackspace.salus.zw.handler.ExpiringZoneEventProcessor;
 import com.rackspace.salus.zw.handler.ZoneEventProcessor;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Watch.Watcher;
+import io.etcd.jetcd.options.WatchOption;
+import io.etcd.jetcd.options.WatchOption.Builder;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -100,7 +101,7 @@ public class EtcdWatchConnector {
             .thenApply(watchRevision -> {
               log.debug("Watching {} from revision {}", watchPrefixStr, watchRevision);
 
-              final ByteSequence watchPrefix = ByteSequence
+              final ByteSequence watchPrefix = EtcdUtils
                   .fromString(watchPrefixStr);
 
               final Builder watchOptionBuilder = WatchOption.newBuilder()
@@ -110,15 +111,11 @@ public class EtcdWatchConnector {
 
               final Watcher zoneWatcher = zoneStorage.getWatchClient().watch(
                   watchPrefix,
-                  watchOptionBuilder.build()
+                  watchOptionBuilder.build(),
+                  watchEventHandler
               );
 
               watchEventHandler.setZoneWatcher(zoneWatcher);
-
-              new Thread(
-                  watchEventHandler,
-                  "zoneWatcher")
-                  .start();
 
               return zoneWatcher;
             });

--- a/src/main/java/com/rackspace/salus/zw/services/ZoneStorageListener.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneStorageListener.java
@@ -16,8 +16,8 @@
 
 package com.rackspace.salus.zw.services;
 
-import com.coreos.jetcd.common.exception.EtcdException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import io.etcd.jetcd.common.exception.EtcdException;
 
 public interface ZoneStorageListener {
 

--- a/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.zw.services;
 
-import com.coreos.jetcd.Watch.Watcher;
-import com.coreos.jetcd.common.exception.EtcdException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.monitor_management.web.client.ZoneApi;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
@@ -25,6 +23,8 @@ import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.ExpiredResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
+import io.etcd.jetcd.Watch.Watcher;
+import io.etcd.jetcd.common.exception.EtcdException;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-474

# What

This is one of our applications that makes indirect use of the jetcd library. Since they are still 0.x they took some liberties with the API switch from 0.0.2 to 0.3.0. (Already notice the change in semantic version position there.)

# How

- Use the new `io.etcd` group for dependencies. They now maintain the unit testing `jetcd-launcher`.
- Switch package references to `io.etcd.jetcd`
- The API leverages more of the asynchronous features of the etcd protocol, such as with the watcher. No longer need to do our own blocking `listen` call
- The string conversion calls don't make their own character set assumptions
- Some of the "data" types are now "top level" types in `io.etcd.jetcd`

# How to test

Existing unit tests all pass still

# Depends on

https://github.com/racker/salus-telemetry-etcd-adapter/pull/43