### PR TITLE
Update unit tests for jetcd 0.3.0 behavior

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/java/com/rackspace/salus/zw/services/ZoneStorageListener.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneStorageListener.java
@@ -17,13 +17,10 @@
 package com.rackspace.salus.zw.services;
 
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
-import io.etcd.jetcd.common.exception.EtcdException;
 
 public interface ZoneStorageListener {
 
   void handleNewEnvoyResourceInZone(ResolvedZone resolvedZone, String resourceId);
-
-  void handleExpectedZoneWatcherClosed(EtcdException e);
 
   void handleEnvoyResourceReassignedInZone(ResolvedZone resolvedZone, String resourceId, String prevEnvoyId, String newEnvoyId);
 

--- a/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
@@ -24,7 +24,6 @@ import com.rackspace.salus.telemetry.messaging.ExpiredResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import io.etcd.jetcd.Watch.Watcher;
-import io.etcd.jetcd.common.exception.EtcdException;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -167,9 +166,4 @@ public class ZoneWatchingService implements ZoneStorageListener {
     );
   }
 
-  @Override
-  public void handleExpectedZoneWatcherClosed(EtcdException e) {
-    // this is normal during application shutdown
-    log.debug("Observed closure while watching expected zones: {}", e.getMessage());
-  }
 }

--- a/src/test/java/com/rackspace/salus/zw/services/ZoneWatchingServiceTest.java
+++ b/src/test/java/com/rackspace/salus/zw/services/ZoneWatchingServiceTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -296,6 +295,10 @@ public class ZoneWatchingServiceTest {
 
     registerAndWatchExpected(resolvedZone, "r-1", "e-1");
 
+    // WORKAROUND until a release after 0.3.0 includes this change: https://github.com/etcd-io/jetcd/commit/d42722530d86579231905512c70fe3521532dcf3
+    tearDown();
+    setUp();
+
     // one envoy-resource has registered, now register another prior to re-watching
 
     final long leaseId = grantLease();
@@ -326,10 +329,6 @@ public class ZoneWatchingServiceTest {
       verify(listener, timeout(5000)).handleNewEnvoyResourceInZone(resolvedZone, "r-2");
 
     } finally {
-      // watcher has been closed
-
-      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
-
       verifyNoMoreInteractions(listener);
     }
 
@@ -359,11 +358,6 @@ public class ZoneWatchingServiceTest {
           resolvedZone, "r-1", "e-1", "e-2");
 
     } finally {
-      // watcher has been closed
-
-      // it is expected that watcher is closed with exception when closed prior to stopping the component
-      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
-
       verifyNoMoreInteractions(listener);
     }
 
@@ -385,11 +379,6 @@ public class ZoneWatchingServiceTest {
 
 
     } finally {
-      // watcher has been closed due to it implementing AutoCloseable
-
-      // it is expected that watcher is closed with exception when closed prior to stopping the component
-      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
-
       verifyNoMoreInteractions(listener);
     }
   }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<!-- jetcd logging was noisy by default in unit tests and Spring Boot unit testing isn't used -->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+
+  <root level="warn">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-474

# What

Update expectations of unit test to handle jetcd 0.3.0 watcher close behavior. Previously, when our code had to create its own thread to doing a blocking calls to `listen()` for events, we explicitly notified other parts of code of the watcher closing, such as

https://github.com/racker/salus-telemetry-zone-watcher/blob/6193cdda10ae252c500df0c7aa82128aeaa82644/src/main/java/com/rackspace/salus/zw/handler/ActiveZoneEventProcessor.java#L99

# How

Now that jetcd manages the asynchronous aspect of watching, the closure handling is generalized into one place in the code here:

https://github.com/racker/salus-telemetry-zone-watcher/blob/134c09cd0d8b0960bec2e9aa1fe2e8f79243796c/src/main/java/com/rackspace/salus/zw/services/EtcdWatchConnector.java#L126

# How to test

Existing unit tests