### PR TITLE
Improve handling of failed zone retrieval during envoy detachment

### DIFF
--- a/src/main/java/com/rackspace/salus/zw/ZoneWatcherApplication.java
+++ b/src/main/java/com/rackspace/salus/zw/ZoneWatcherApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.zw;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.telemetry.etcd.EnableEtcd;
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 @EnableSalusKafkaMessaging
 @EnableEtcd
+@AutoConfigureSalusAppMetrics
 public class ZoneWatcherApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-806

# What

The fix for the root cause of zone watcher crashing during public-envoy-poller reattachment is over in https://github.com/racker/salus-telemetry-monitor-management/pull/147 ; however, the code still should be made more robust for failed remote calls.

# How

Since the remote call is only there to lookup the poller timeout of the zone, introduced a fallback logic and value. Added an "errors" metric for the condition and auto-configure the metrics tags.

# How to test

Updated unit tests