### PR TITLE
Handle zones that have been removed

### DIFF
--- a/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
@@ -42,6 +42,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ZoneWatchingService implements ZoneStorageListener {
 
+  static final long NULL_ZONE_POLLER_TIMEOUT = 30;
   static final long FALLBACK_POLLER_TIMEOUT = 300;
 
   private final ZoneStorage zoneStorage;
@@ -160,6 +161,10 @@ public class ZoneWatchingService implements ZoneStorageListener {
     try {
       pollerTimeout = zoneApi.getByZoneName(resolvedZone.getTenantId(), resolvedZone.getName())
           .getPollerTimeout();
+    } catch (NullPointerException npe) {
+      log.debug("Envoy disconnected from zone that does not exist anymore {}", resolvedZone);
+      retrievePollerTimeoutErrors.increment();
+      pollerTimeout = NULL_ZONE_POLLER_TIMEOUT;
     } catch (IllegalArgumentException e) {
       log.warn("Call to get poller timeout by zone name failed; using fallback timeout", e);
       retrievePollerTimeoutErrors.increment();

--- a/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zw/services/ZoneWatchingService.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.zw.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.monitor_management.web.client.ZoneApi;
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.ExpiredResourceZoneEvent;
@@ -159,12 +160,14 @@ public class ZoneWatchingService implements ZoneStorageListener {
 
     long pollerTimeout;
     try {
-      pollerTimeout = zoneApi.getByZoneName(resolvedZone.getTenantId(), resolvedZone.getName())
-          .getPollerTimeout();
-    } catch (NullPointerException npe) {
-      log.debug("Envoy disconnected from zone that does not exist anymore {}", resolvedZone);
-      retrievePollerTimeoutErrors.increment();
-      pollerTimeout = NULL_ZONE_POLLER_TIMEOUT;
+      ZoneDTO zone = zoneApi.getByZoneName(resolvedZone.getTenantId(), resolvedZone.getName());
+      if (zone == null) {
+        log.debug("Envoy disconnected from zone that does not exist anymore {}", resolvedZone);
+        retrievePollerTimeoutErrors.increment();
+        pollerTimeout = NULL_ZONE_POLLER_TIMEOUT;
+      } else {
+        pollerTimeout = zone.getPollerTimeout();
+      }
     } catch (IllegalArgumentException e) {
       log.warn("Call to get poller timeout by zone name failed; using fallback timeout", e);
       retrievePollerTimeoutErrors.increment();


### PR DESCRIPTION
# What

Fixes a bug when an envoy disconnects that was previously part of a zone that has since been removed.

# Why

Discovered this while running e2e tests locally.

I think in prod it shouldn't be possible to remove a zone that still has pollers (I had already added a test case for that to the qe doc) so this may never really get hit... but that may not be the case right now.