### PR TITLE
Added apis to get detached but pending timeout pollers

### DIFF
--- a/src/main/java/com/rackspace/salus/zw/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/zw/web/controller/ZoneApiController.java
@@ -2,16 +2,18 @@ package com.rackspace.salus.zw.web.controller;
 
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
-import com.rackspace.salus.telemetry.etcd.types.PublicZoneName;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Slf4j
 @RestController
@@ -25,19 +27,51 @@ public class ZoneApiController {
     this.zoneStorage = zoneStorage;
   }
 
-  @GetMapping("/admin/zone/{zone}/detached-pollers")
-  public CompletableFuture<List<String>> getExpiredPollerAdmin(
-      @PathVariable @PublicZoneName String zone) {
-
+  @GetMapping("/admin/zone/**")
+  public CompletableFuture<List<String>> getExpiredPollerAdmin(HttpServletRequest request) {
+    String zone = extractPublicZoneNameFromUri(request);
     ResolvedZone resolvedZone = ResolvedZone.createPublicZone(zone);
     return zoneStorage.getExpiredPollerResourceIdsInZone(resolvedZone);
   }
 
-  @GetMapping("/tenant/{tenantId}/zone/{zone}/detaches-pollers")
+  @GetMapping("/tenant/{tenantId}/zone/{zone}/detached-pollers")
   public CompletableFuture<List<String>> getExpiredPollerPublic(@PathVariable String tenantId,
       @PathVariable @PrivateZoneName String zone) {
 
     ResolvedZone resolvedZone = ResolvedZone.createPrivateZone(tenantId, zone);
     return zoneStorage.getExpiredPollerResourceIdsInZone(resolvedZone);
+  }
+
+  /**
+   * Discovers the zone name within the uri. Handles both public zones containing slashes as well as
+   * more simple private zone. Using @PathVariable does not work for public zones.
+   *
+   * @param request The incoming http request.
+   * @return The zone name provided within the uri.
+   */
+  private String extractZoneNameFromUri(HttpServletRequest request) {
+    // For example, /api/admin//zones/public/region_1
+    String path = (String) request
+        .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+    // For example, /api/admin/zones/**
+    String bestMatchPattern = (String) request
+        .getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+    // For example, public/region_1
+    return new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
+  }
+
+  /**
+   * Helper method that calls {@link #extractZoneNameFromUri(HttpServletRequest)} but also validates
+   * the zone name is a legal public zone name.
+   *
+   * @param request The incoming http request.
+   * @return The zone name provided within the uri.
+   */
+  private String extractPublicZoneNameFromUri(HttpServletRequest request) {
+    final String name = extractZoneNameFromUri(request);
+    if (!name.startsWith(ResolvedZone.PUBLIC_PREFIX)) {
+      throw new IllegalArgumentException("Must provide a public zone name");
+    }
+    return name;
   }
 }

--- a/src/main/java/com/rackspace/salus/zw/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/zw/web/controller/ZoneApiController.java
@@ -1,0 +1,43 @@
+package com.rackspace.salus.zw.web.controller;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
+import com.rackspace.salus.telemetry.etcd.types.PublicZoneName;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class ZoneApiController {
+
+  ZoneStorage zoneStorage;
+
+  @Autowired
+  public ZoneApiController(ZoneStorage zoneStorage) {
+    this.zoneStorage = zoneStorage;
+  }
+
+  @GetMapping("/admin/zone/{zone}/detached-pollers")
+  public CompletableFuture<List<String>> getExpiredPollerAdmin(
+      @PathVariable @PublicZoneName String zone) {
+
+    ResolvedZone resolvedZone = ResolvedZone.createPublicZone(zone);
+    return zoneStorage.getExpiredPollerResourceIdsInZone(resolvedZone);
+  }
+
+  @GetMapping("/tenant/{tenantId}/zone/{zone}/detaches-pollers")
+  public CompletableFuture<List<String>> getExpiredPollerPublic(@PathVariable String tenantId,
+      @PathVariable @PrivateZoneName String zone) {
+
+    ResolvedZone resolvedZone = ResolvedZone.createPrivateZone(tenantId, zone);
+    return zoneStorage.getExpiredPollerResourceIdsInZone(resolvedZone);
+  }
+}

--- a/src/test/java/com/rackspace/salus/zw/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/zw/web/controller/ZoneApiControllerTest.java
@@ -1,0 +1,80 @@
+package com.rackspace.salus.zw.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ZoneApiController.class)
+public class ZoneApiControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  ZoneStorage zoneStorage;
+
+  @Test
+  public void testGetExpiredPollerPublicZone() throws Exception {
+
+    when(zoneStorage.getExpiredPollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("r-1", "r-2")));
+
+    ResolvedZone resolvedZone = ResolvedZone.createPublicZone("public/testPublicZone");
+    final MvcResult result = mvc.perform(
+        get("/api/admin/zone/{name}",
+            "public/testPublicZone"
+        )
+    )
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    mvc.perform(asyncDispatch(result))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("*").value(Matchers.containsInAnyOrder("r-1", "r-2")));
+
+    verify(zoneStorage).getExpiredPollerResourceIdsInZone(resolvedZone);
+  }
+
+  @Test
+  public void testGetExpiredPollerPrivateZone() throws Exception {
+
+    when(zoneStorage.getExpiredPollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("r-1", "r-2")));
+
+    ResolvedZone resolvedZone = ResolvedZone.createPrivateZone("t-1", "testZone");
+
+    final MvcResult result = mvc.perform(
+        get("/api/tenant/{tenantId}/zone/{name}/detached-pollers",
+            "t-1", "testZone"
+        )
+    )
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    mvc.perform(asyncDispatch(result))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("*").value(Matchers.containsInAnyOrder("r-1", "r-2")));
+
+    verify(zoneStorage).getExpiredPollerResourceIdsInZone(resolvedZone);
+  }
+}


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-992

# What
Added apis to get detached but pending timeout pollers

# How
Added 2 new apis for public and admin to get the list of detached but pending timeout pollers.

# How to test
This can be tested via Rest call.